### PR TITLE
add amanuensis hooks

### DIFF
--- a/helm/amanuensis/templates/amanuensis-clear-filter-set-cronjob.yaml
+++ b/helm/amanuensis/templates/amanuensis-clear-filter-set-cronjob.yaml
@@ -4,6 +4,12 @@ metadata:
   name: amanuensis-clear-unused-filter-sets
   labels:
     redeploy-hash: "{{ .Release.Revision }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    app: gen3-created-by-hook
 spec:
   schedule: "0 0 1 * *"
   concurrencyPolicy: Forbid
@@ -26,9 +32,17 @@ spec:
             - name: config-volume
               secret:
                 secretName: "amanuensis-config"
+                items:
+                  - key: amanuensis-config.yaml
+                    path: amanuensis-config.yaml
+                optional: false
             - name: amanuensis-volume
               secret:
                 secretName: "amanuensis-creds"
+                items:
+                  - key: creds.json
+                    path: creds.json
+                optional: false
             - name: tmp-pod
               emptyDir: {}
           containers:

--- a/helm/amanuensis/templates/amanuensis-db-migrate-job.yaml
+++ b/helm/amanuensis/templates/amanuensis-db-migrate-job.yaml
@@ -3,6 +3,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: amanuensis-db-migrate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    app: gen3-created-by-hook
 spec:
   template:
     metadata:
@@ -18,9 +24,17 @@ spec:
         - name: config-volume
           secret:
             secretName: "amanuensis-config"
+            items:
+              - key: amanuensis-config.yaml
+                path: amanuensis-config.yaml
+            optional: false
         - name: amanuensis-volume
           secret:
             secretName: "amanuensis-creds"
+            items:
+              - key: creds.json
+                path: creds.json
+            optional: false
         - name: tmp-pod
           emptyDir: {}
       containers:

--- a/helm/amanuensis/templates/amanuensis-secret.yaml
+++ b/helm/amanuensis/templates/amanuensis-secret.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: amanuensis-secret
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+  labels:
+    app: gen3-created-by-hook
 type: Opaque
 data:
 {{ (.Files.Glob "amanuensis-secret/*").AsSecrets | indent 2 }}

--- a/helm/amanuensis/templates/amanuensis-secrets.yaml
+++ b/helm/amanuensis/templates/amanuensis-secrets.yaml
@@ -2,11 +2,17 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: amanuensis-jobs
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-3"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: amanuensis-jobs-role
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-3"
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -16,6 +22,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amanuensis-jobs-role-binding
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -29,6 +38,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: amanuensis-config
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-2"
+  labels:
+    app: gen3-created-by-hook
 data:
   {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (printf "amanuensis-config")) }}
   {{- if and $existingSecret $existingSecret.data (hasKey $existingSecret.data "amanuensis-config.yaml") }}
@@ -41,6 +55,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: amanuensis-creds
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-2"
+  labels:
+    app: gen3-created-by-hook
 data:
   {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (printf "amanuensis-creds")) }}
   {{- if and $existingSecret $existingSecret.data (hasKey $existingSecret.data "creds.json") }}
@@ -63,7 +82,13 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: amanuensis-secrets-{{ .Release.Revision }}
+  name: amanuensis-secrets
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    app: gen3-created-by-hook
 spec:
   backoffLimit: 0
   template:

--- a/helm/amanuensis/templates/amanuensis-validate-filter-sets-job.yaml
+++ b/helm/amanuensis/templates/amanuensis-validate-filter-sets-job.yaml
@@ -4,6 +4,12 @@ metadata:
   name: amanuensis-validate-filter-sets
   labels:
     redeploy-hash: "{{ .Release.Revision }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    app: gen3-created-by-hook
 spec:
   # Job spec starts here directly (no schedule or jobTemplate needed)
   template:
@@ -16,6 +22,10 @@ spec:
         - name: config-volume
           secret:
             secretName: "amanuensis-config"
+            items:
+              - key: amanuensis-config.yaml
+                path: amanuensis-config.yaml
+            optional: false
         - name: es-dd-config-volume
           emptyDir: {}
         - name: portal-config

--- a/helm/common/templates/_db_setup_job.tpl
+++ b/helm/common/templates/_db_setup_job.tpl
@@ -174,6 +174,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $.Chart.Name }}-dbcreds
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+  labels:
+    app: gen3-created-by-hook
 data:
   {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-dbcreds" .Chart.Name)) }}
   {{- if $existingSecret }}

--- a/helm/fence/values.yaml
+++ b/helm/fence/values.yaml
@@ -428,7 +428,7 @@ volumes:
   - name: config-volume-public
     configMap:
       name: "manifest-fence"
-    optional: true
+      optional: true
 
 # -- (list) Volumes to mount to the container.
 volumeMounts:

--- a/helm/gen3/templates/cleanup-helm-hooks-job.yaml
+++ b/helm/gen3/templates/cleanup-helm-hooks-job.yaml
@@ -26,7 +26,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups: ["batch"]
-  resources: ["jobs"]
+  resources: ["jobs", "cronjobs"]
   verbs: ["get", "list", "delete"]
 - apiGroups: [""]
   resources: ["pods"]
@@ -80,8 +80,11 @@ spec:
           echo "Cleaning up hook resources for release: {{ .Release.Name }}"
           
           # Clean up jobs created by hooks
-          kubectl delete jobs -l app=gen3-created-by-hook    
+          kubectl delete jobs -l app=gen3-created-by-hook   
           
+          # Clean up cronjobs created by hooks
+          kubectl delete cronjobs -l app=gen3-created-by-hook
+
           # Clean up secrets created by hooks (if any)
           kubectl delete secrets -l app=gen3-created-by-hook   
           echo "Cleanup completed"

--- a/helm/gen3/templates/cleanup-helm-hooks-job.yaml
+++ b/helm/gen3/templates/cleanup-helm-hooks-job.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gen3.fullname" . }}-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gen3.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+automountServiceAccountToken: true
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "gen3.fullname" . }}-cleanup-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gen3.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gen3.fullname" . }}-cleanup-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gen3.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gen3.fullname" . }}-cleanup
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "gen3.fullname" . }}-cleanup-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "gen3.fullname" . }}-cleanup-{{ randAlphaNum 8 | lower }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 60
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "gen3.fullname" . }}-cleanup
+      containers:
+      - name: cleanup
+        image: bitnami/kubectl:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          echo "Cleaning up hook resources for release: {{ .Release.Name }}"
+          
+          # Clean up jobs created by hooks
+          kubectl delete jobs -l app=gen3-created-by-hook    
+          
+          # Clean up secrets created by hooks (if any)
+          kubectl delete secrets -l app=gen3-created-by-hook   
+          echo "Cleanup completed"

--- a/helm/pcdcanalysistools/Chart.yaml
+++ b/helm/pcdcanalysistools/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: common
-    version: 0.1.16
+    version: 0.1.20
     repository: file://../common

--- a/helm/pcdcanalysistools/pcdcanalysistools-secret/settings.py
+++ b/helm/pcdcanalysistools/pcdcanalysistools-secret/settings.py
@@ -111,6 +111,28 @@ config['SURVIVAL'] = {
     }
 }
 
+config['TABLE_ONE'] = {
+    'consortium': ["INSTRuCT", "INRG", "MaGIC", "NODAL"],
+    'excluded_variables': [
+        {
+            'label': 'Data Contributor',
+            'field': 'data_contributor_id',
+        },
+        {
+            'label': 'Study',
+            'field': 'studies.study_id',
+        },
+        {
+            'label': 'Treatment Arm',
+            'field': 'studies.treatment_arm',
+        }
+    ],
+
+    'result': {
+        "enabled": True
+    }
+}
+
 config['EXTERNAL'] = {
     'commons': [
         {

--- a/helm/pcdcanalysistools/templates/deployment.yaml
+++ b/helm/pcdcanalysistools/templates/deployment.yaml
@@ -131,8 +131,6 @@ spec:
                   name: manifest-global
                   key: fence_url
                   optional: true
-            - name: FLASK_SECRET_KEY
-              value: "TODO: FIX THIS!!!"
             - name: ARBORIST_URL
               value: http://arborist-service
             - name: AUTH_NAMESPACE
@@ -141,10 +139,6 @@ spec:
               value: /etc/ssl/certs/ca-certificates.crt
             - name: GEN3_DEBUG
               value: "False"
-            - name: FLASK_ENV
-              value: development
-            - name: FLASK_APP
-              value: PcdcAnalysisTools.wsgi
           volumeMounts:
             - name: "config-volume"
               readOnly: true

--- a/pcdc-default-values.yaml
+++ b/pcdc-default-values.yaml
@@ -63,7 +63,7 @@ amanuensis:
   enabled: true
   image:
     repository: "quay.io/pcdc/amanuensis"
-    tag: "2.24.0"
+    tag: "2.26.2"
     pullPolicy: IfNotPresent
 
 fence: 
@@ -335,7 +335,7 @@ portal:
 revproxy:
   image:
     repository: quay.io/cdis/nginx
-    tag: "1.17.6-ctds-1.0.1"
+    tag: "2025.07"
 
 sheepdog:
   image:

--- a/pcdc-default-values.yaml
+++ b/pcdc-default-values.yaml
@@ -4,6 +4,8 @@ global:
   portalApp: pcdc
   dictionaryUrl: https://pcdc-staging-dictionaries.s3.amazonaws.com/pcdc-schema-staging-20250114.json
   authz_entity_name: "subject"
+  tierAccessLevel: "granular"
+  tierAccessLimit: "5"
   tls:
     cert: |
       -----BEGIN CERTIFICATE-----
@@ -55,7 +57,7 @@ global:
       -----END RSA PRIVATE KEY-----
 
 arborist:
-  image: 
+  image:
     repository: quay.io/pcdc/arborist
     tag: "2025.01"
 
@@ -66,17 +68,16 @@ amanuensis:
     tag: "2.26.2"
     pullPolicy: IfNotPresent
 
-fence: 
+fence:
   FENCE_CONFIG:
     DEBUG: true
     MOCK_STORAGE: true
     #fill in
     #AMANUENSIS_PUBLIC_KEY_PATH: '/fence/keys/key/jwt_public_key.pem'
     MOCK_GOOGLE_AUTH: true
-    mock_default_user: 'test@example.com'
+    mock_default_user: "test@example.com"
     #LOGIN_REDIRECT_WHITELIST: ["https://localhost:9443/", "http://localhost:9443/"]
-    
-    
+
   image:
     repository: "quay.io/pcdc/fence"
     tag: "helm-test"
@@ -186,7 +187,7 @@ fence:
             - /programs
             - /programs/pcdc
           
-    
+
       roles:
         - id: 'file_uploader'
           description: 'can upload data files'
@@ -294,13 +295,13 @@ fence:
           - privacy_policy
           - login_no_access
           - sower
-      
 
 guppy:
   enabled: true
   image:
-    repository: quay.io/pcdc/guppy 
-    tag: 1.9.1
+    repository: "guppy"
+    tag: "test"
+    pullPolicy: "Never"
   authFilterField: "auth_resource_path"
 
 manifestservice:
@@ -313,7 +314,7 @@ pcdcanalysistools:
   enabled: true
   image:
     repository: quay.io/pcdc/pcdcanalysistools
-    tag: "1.8.9"
+    tag: "1.10.0"
 
 peregrine:
   image:
@@ -322,14 +323,14 @@ peregrine:
 
 portal:
   #enabled: false
-  image: 
+  image:
     repository: "quay.io/pcdc/windmill"
-    tag: "1.36.1"
+    tag: "1.41.0"
     pullPolicy: IfNotPresent
   resources:
     requests:
       cpu: 1.0
-  gitops: 
+  gitops:
     json: ""
 
 revproxy:
@@ -359,20 +360,20 @@ sower:
         image: quay.io/pcdc/pelican:1.3.3_export
         pull_policy: Always
         env:
-        - name: DICTIONARY_URL
-          valueFrom:
-            configMapKeyRef:
-              name: manifest-global
-              key: dictionary_url
-        - name: GEN3_HOSTNAME
-          valueFrom:
-            configMapKeyRef:
-              name: manifest-global
-              key: hostname
-        - name: ROOT_NODE
-          value: subject
-        - name: OUTPUT_FILE_FORMAT
-          value: ZIP
+          - name: DICTIONARY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: dictionary_url
+          - name: GEN3_HOSTNAME
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: hostname
+          - name: ROOT_NODE
+            value: subject
+          - name: OUTPUT_FILE_FORMAT
+            value: ZIP
         volumeMounts:
           - name: pelican-creds-volume
             readOnly: true
@@ -382,7 +383,7 @@ sower:
             readOnly: true
             mountPath: "/peregrine-creds.json"
             subPath: creds.json
-        cpu-limit: '1'
+        cpu-limit: "1"
         memory-limit: 2Gi
       volumes:
         - name: pelican-creds-volume
@@ -414,7 +415,7 @@ elasticsearch:
   esConfig:
     elasticsearch.yml: |
       # Here we can add elasticsearch config
-    
+
   resources:
     requests:
       cpu: 0.5

--- a/tools/roll.sh
+++ b/tools/roll.sh
@@ -80,4 +80,4 @@ else
 fi
 
 # Run helm upgrade --install command
-helm upgrade --install $project . -f ../../values.yaml
+helm upgrade --install $project . -f ../../values.yaml --timeout 15m0s


### PR DESCRIPTION
This what I came up with as the solution to dealing with timing issues with the resources which goes back to the strategy of utilizing hooks but also adds a job in the gen3 chart which runs when you uninstall the gen3 chart (delete everything) which goes through and deletes all the resources that use hooks (since resources that are hooks dont get deleted during an uninstall). I will start to look at other charts in the future but generally I think we want to make all jobs hooks