### PR TITLE
Fail to delete in helm, resolved with this solution

### DIFF
--- a/helm/common/templates/_jwt_key_pairs.tpl
+++ b/helm/common/templates/_jwt_key_pairs.tpl
@@ -53,7 +53,7 @@ spec:
       serviceAccountName: {{ .Chart.Name }}-jwt-public-key-patch-sa
       containers:
       - name: public-key-gen
-        image: bitnami/kubectl:latest
+        image: bitnamisecure/kubectl:latest
         env:
           - name: PRIVATE_KEY_PEM
             valueFrom:

--- a/helm/gen3/templates/cleanup-helm-hooks-job.yaml
+++ b/helm/gen3/templates/cleanup-helm-hooks-job.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: {{ include "gen3.fullname" . }}-cleanup
       containers:
       - name: cleanup
-        image: bitnami/kubectl:latest
+        image: bitnamisecure/kubectl:latest
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Jira: https://pcdc.atlassian.net/browse/GEAR-525

Issue - Helm delete <env> would not finish, and eventually timeout. Although if you went to another terminal, it would show missing. The user also had to reset kubctl to build again.
<img width="1824" height="728" alt="Screenshot 2025-09-18 at 11 47 54 AM" src="https://github.com/user-attachments/assets/31509e6e-ac7d-4a9c-86ca-eb2b8f67a37d" />

Resolution - helm finishes the delete and the user does not need to reset kubectl.
<img width="989" height="456" alt="Screenshot 2025-09-18 at 1 55 11 PM" src="https://github.com/user-attachments/assets/60ee6bda-2394-4e1e-81ca-db0d2a73d7d2" />

@paulmurdoch19 this works as we talked about, thanks for the direction on what needed to be resolved.

Solution: the bitnami/kubectl:latest image was yanked recently you need to use bitnamisecure/kubectl:latest now
