### PR TITLE
Move 'enabled' flag to TABLE_ONE config root

### DIFF
--- a/helm/pcdcanalysistools/pcdcanalysistools-secret/settings.py
+++ b/helm/pcdcanalysistools/pcdcanalysistools-secret/settings.py
@@ -123,10 +123,7 @@ config['TABLE_ONE'] = {
             'field': 'studies.treatment_arm',
         }
     ],
-
-    'result': {
-        "enabled": True
-    }
+    "enabled": True
 }
 
 config['EXTERNAL'] = {


### PR DESCRIPTION
Refactored the TABLE_ONE configuration by moving the 'enabled' flag from the nested 'result' dictionary to the root level of TABLE_ONE. This simplifies the configuration structure.