### PR TITLE
Add DB credentials to environment variables

### DIFF
--- a/helm/gearbox-middleware/values.yaml
+++ b/helm/gearbox-middleware/values.yaml
@@ -160,6 +160,36 @@ terminationGracePeriodSeconds: 50
 env:
   - name: GEN3_DEBUG
     value: "False"
+  - name: DB_DATABASE
+    valueFrom:
+      secretKeyRef:
+        name: gearbox-dbcreds
+        key: database
+        optional: false
+  - name: DB_HOST
+    valueFrom:
+      secretKeyRef:
+        name: gearbox-dbcreds
+        key: host
+        optional: false
+  - name: DB_USER
+    valueFrom:
+      secretKeyRef:
+        name: gearbox-dbcreds
+        key: username
+        optional: false
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: gearbox-dbcreds
+        key: password
+        optional: false
+  - name: DBREADY
+    valueFrom:
+      secretKeyRef:
+        name: gearbox-dbcreds
+        key: dbcreated
+        optional: false
 
 # -- (list) Volumes to mount to the container.
 volumeMounts:


### PR DESCRIPTION
Introduced environment variables for database connection (DB_DATABASE, DB_HOST, DB_USER, DB_PASSWORD, DBREADY) sourced from the gearbox-dbcreds secret in values.yaml. This enables the application to securely access database credentials via Kubernetes secrets.