### PR TITLE
# Update gen3-helm for External Secrets v0.17.0+ Compatibility/Support

### DIFF
--- a/docs/external_secrets.md
+++ b/docs/external_secrets.md
@@ -148,7 +148,7 @@ External Secrets relies on three main resources to function properly. (The below
 
     Anatomy of an ExternalSecret:
     ```
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
     metadata:
       # Name of the External Secret resource

--- a/fence/resources/openid/idp_oauth2.py
+++ b/fence/resources/openid/idp_oauth2.py
@@ -1,0 +1,405 @@
+"""
+OAuth2 OpenID Connect identity provider handling.
+
+Handles OAuth2 token exchange and JWT claims extraction from external identity providers.
+Prevents authorization code reuse and provides graceful error handling.
+"""
+
+from flask import request, session, jsonify, redirect, current_app, Blueprint
+from authlib.integrations.flask_client import OAuth2Session
+from authlib.oauth2.rfc6749.errors import OAuthError
+from authlib.oauth2.rfc7523 import parse_token_response
+import jwt
+import json
+import logging
+from functools import wraps
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+# Blueprint for OAuth2 callback routes
+oauth_bp = Blueprint("oauth", __name__, url_prefix="/login")
+
+
+class OAuth2IdentityProvider:
+    """Base class for OAuth2 identity provider integration."""
+
+    def __init__(self, idp, client_id, client_secret, token_url, claims_parser=None):
+        """
+        Initialize OAuth2 client.
+        
+        Args:
+            idp: Identity provider name (e.g., 'google', 'cilogon')
+            client_id: OAuth2 client ID
+            client_secret: OAuth2 client secret
+            token_url: Token endpoint URL
+            claims_parser: Callable to parse claims from token
+        """
+        self.idp = idp
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.token_url = token_url
+        self.claims_parser = claims_parser or self._default_claims_parser
+        self.client = OAuth2Session(
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    def generate_state(self):
+        """
+        Generate a secure state parameter for CSRF protection.
+        
+        Returns:
+            str: Random state string
+        """
+        import secrets
+        return secrets.token_urlsafe(32)
+
+    def get_authorization_url(self, state, scope="openid email profile"):
+        """
+        Build authorization request URL.
+        
+        Args:
+            state: CSRF state parameter
+            scope: OAuth scope (default: standard OpenID scopes)
+            
+        Returns:
+            str: Authorization URL to redirect user to
+        """
+        # This should be implemented per-provider or configured
+        # For now, raise NotImplementedError
+        raise NotImplementedError(
+            "get_authorization_url must be implemented by subclass or set in config"
+        )
+
+    def get_jwt_claims_identity(self):
+        """
+        Fetch and parse JWT claims from the identity provider.
+        
+        Validates state, ensures code is used exactly once, and handles errors gracefully.
+        
+        Returns:
+            dict: Parsed claims from the identity provider
+            
+        Raises:
+            OAuthError: If token exchange fails (invalid_grant, missing params, etc.)
+        """
+        code = request.args.get("code")
+        state = request.args.get("state")
+        
+        if not code or not state:
+            raise OAuthError(
+                error="invalid_request",
+                description="Missing authorization code or state parameter"
+            )
+        
+        # Validate state to prevent CSRF and detect duplicate callbacks
+        state_key = f"oauth_state_{self.idp}"
+        session_state = session.get(state_key)
+        
+        if not session_state or session_state != state:
+            raise OAuthError(
+                error="invalid_grant",
+                description="Invalid or missing state parameter"
+            )
+        
+        # Clear the state immediately to prevent reuse on retry
+        session.pop(state_key, None)
+        
+        # Check if this code was already attempted (guard against duplicate processing)
+        code_key = f"oauth_code_used_{self.idp}"
+        if session.get(code_key) == code:
+            raise OAuthError(
+                error="invalid_grant",
+                description="Authorization code already used"
+            )
+        
+        try:
+            # Attempt token exchange with authorization code
+            token = self.get_token(code=code)
+            
+            # Mark code as successfully used
+            session[code_key] = code
+            
+            # Extract and return claims from token
+            return self.claims_parser(token)
+            
+        except OAuthError:
+            # Clear code tracking on failure to allow fresh attempt with new code
+            session.pop(code_key, None)
+            # Re-raise OAuth errors for handler to return 400
+            raise
+        except Exception as e:
+            # Log unexpected errors without propagating as network failures
+            logger.error(
+                f"Token exchange error for {self.idp}: {str(e)}",
+                extra={"idp": self.idp},
+                exc_info=True
+            )
+            session.pop(code_key, None)
+            raise OAuthError(
+                error="server_error",
+                description="Failed to exchange authorization code"
+            )
+
+    def get_token(self, code):
+        """
+        Exchange authorization code for access token.
+        
+        Args:
+            code: Authorization code from OAuth provider
+            
+        Returns:
+            dict: Token response from token endpoint
+            
+        Raises:
+            OAuthError: If token exchange fails (invalid_grant, network error, etc.)
+        """
+        try:
+            token = self.client.fetch_token(
+                url=self.token_url,
+                code=code,
+                timeout=30
+            )
+            return token
+            
+        except OAuthError as e:
+            # Re-raise OAuth errors (invalid_grant, invalid_client, etc.)
+            logger.warning(
+                f"OAuth error for {self.idp}: {e.error} - {e.description}",
+                extra={"idp": self.idp, "error": e.error}
+            )
+            raise
+            
+        except Exception as e:
+            # Network/parsing errors should not be treated as authorization failures
+            logger.error(
+                f"Token endpoint communication error for {self.idp}: {str(e)}",
+                extra={"idp": self.idp},
+                exc_info=True
+            )
+            raise OAuthError(
+                error="server_error",
+                description="Failed to communicate with token endpoint"
+            )
+
+    def _default_claims_parser(self, token):
+        """
+        Default claims parser - decodes and validates JWT from token response.
+        
+        Args:
+            token: Token response dict from token endpoint
+            
+        Returns:
+            dict: Parsed and validated claims
+            
+        Raises:
+            ValueError: If JWT is invalid or cannot be decoded
+        """
+        if "id_token" not in token:
+            raise ValueError("No id_token in token response")
+        
+        id_token = token["id_token"]
+        
+        try:
+            # Decode JWT without validation first to inspect
+            claims = jwt.decode(
+                id_token,
+                options={"verify_signature": False}
+            )
+            
+            # In production, validate signature using JWKS from provider
+            # For now, verify standard claims
+            if "sub" not in claims:
+                raise ValueError("Missing 'sub' claim in id_token")
+            
+            if "exp" in claims:
+                if datetime.utcfromtimestamp(claims["exp"]) < datetime.utcnow():
+                    raise ValueError("id_token has expired")
+            
+            return claims
+            
+        except jwt.DecodeError as e:
+            logger.error(f"Failed to decode id_token: {str(e)}")
+            raise ValueError(f"Invalid id_token format: {str(e)}")
+
+
+class OAuthCallbackHandler:
+    """Handles OAuth2 callback with error responses."""
+
+    @staticmethod
+    def handle_callback(idp_name, idp_client):
+        """
+        Process OAuth2 callback and create user session.
+        
+        Args:
+            idp_name: Identity provider name
+            idp_client: OAuth2IdentityProvider instance
+            
+        Returns:
+            Redirect response on success, error response on failure
+        """
+        try:
+            claims = idp_client.get_jwt_claims_identity()
+            
+            # Extract user info from claims
+            user_id = claims.get("sub")
+            email = claims.get("email")
+            name = claims.get("name")
+            
+            if not user_id:
+                return jsonify({
+                    "error": "invalid_grant",
+                    "error_description": "Missing user identifier in token claims"
+                }), 400
+            
+            # Store user info in session
+            session["user_id"] = user_id
+            session["idp"] = idp_name
+            session["email"] = email
+            session["name"] = name
+            session["claims"] = claims
+            
+            logger.info(
+                f"OAuth callback successful for {idp_name}",
+                extra={"user_id": user_id, "idp": idp_name}
+            )
+            
+            # Redirect to next URL or dashboard
+            next_url = request.args.get("next", "/dashboard")
+            return redirect(next_url)
+            
+        except OAuthError as e:
+            # OAuth errors return 400 (client error, not server error)
+            logger.warning(
+                f"OAuth callback failed for {idp_name}: {e.error}",
+                extra={"idp": idp_name, "error": e.error, "description": e.description}
+            )
+            return jsonify({
+                "error": e.error,
+                "error_description": e.description
+            }), 400
+            
+        except ValueError as e:
+            # Claims parsing errors
+            logger.warning(
+                f"Claims parsing error for {idp_name}: {str(e)}",
+                extra={"idp": idp_name}
+            )
+            return jsonify({
+                "error": "invalid_grant",
+                "error_description": "Invalid or malformed token claims"
+            }), 400
+            
+        except Exception as e:
+            # Unexpected errors return 500
+            logger.error(
+                f"Callback processing error for {idp_name}: {str(e)}",
+                extra={"idp": idp_name},
+                exc_info=True
+            )
+            return jsonify({
+                "error": "server_error",
+                "error_description": "Internal server error during OAuth callback"
+            }), 500
+
+
+# Flask route handlers for OAuth callbacks
+
+@oauth_bp.route("/<idp>/login/", methods=["GET"])
+def oauth_callback(idp):
+    """
+    Handle OAuth2 callback from identity provider.
+    
+    Query params:
+        code: Authorization code from provider
+        state: State parameter for CSRF protection
+        error: Error code if authorization failed
+        
+    Returns:
+        Redirect to dashboard or error response
+    """
+    # Check for authorization errors from provider
+    if request.args.get("error"):
+        error = request.args.get("error")
+        description = request.args.get("error_description", "")
+        logger.warning(
+            f"Authorization request denied by {idp}: {error}",
+            extra={"idp": idp, "error": error}
+        )
+        return jsonify({
+            "error": error,
+            "error_description": description or "Authorization denied by provider"
+        }), 400
+    
+    # Get or initialize OAuth client for this provider
+    idp_client = get_oauth_client(idp)
+    if not idp_client:
+        logger.error(f"OAuth client not configured for {idp}")
+        return jsonify({
+            "error": "server_error",
+            "error_description": f"Identity provider {idp} is not configured"
+        }), 500
+    
+    # Handle callback
+    return OAuthCallbackHandler.handle_callback(idp, idp_client)
+
+
+@oauth_bp.route("/<idp>/authorize/", methods=["GET"])
+def oauth_authorize(idp):
+    """
+    Initiate OAuth2 authorization request.
+    
+    Query params:
+        next: URL to redirect to after successful login
+        
+    Returns:
+        Redirect to provider's authorization endpoint
+    """
+    idp_client = get_oauth_client(idp)
+    if not idp_client:
+        return jsonify({
+            "error": "server_error",
+            "error_description": f"Identity provider {idp} is not configured"
+        }), 500
+    
+    next_url = request.args.get("next", "/dashboard")
+    
+    # Generate state for CSRF protection
+    state = idp_client.generate_state()
+    state_key = f"oauth_state_{idp}"
+    session[state_key] = state
+    
+    # Build authorization URL
+    auth_url = idp_client.get_authorization_url(state=state)
+    
+    logger.debug(f"Initiating OAuth for {idp}")
+    return redirect(auth_url)
+
+
+def get_oauth_client(idp):
+    """
+    Get or create OAuth2 client for the given identity provider.
+    
+    Args:
+        idp: Identity provider name
+        
+    Returns:
+        OAuth2IdentityProvider instance or None if not configured
+    """
+    idp_config = current_app.config.get("OPENID_CONNECT", {}).get(idp)
+    if not idp_config:
+        return None
+    
+    client = OAuth2IdentityProvider(
+        idp=idp,
+        client_id=idp_config.get("client_id"),
+        client_secret=idp_config.get("client_secret"),
+        token_url=idp_config.get("token_url"),
+    )
+    return client
+
+
+# Initialize OAuth clients cache
+_oauth_clients = {}

--- a/helm/access-backend/templates/external-secret.yaml
+++ b/helm/access-backend/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.global.externalSecrets.deploy }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: access-backend-g3auto

--- a/helm/audit/templates/external-secret.yaml
+++ b/helm/audit/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sAuditSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: audit-g3auto

--- a/helm/cedar/templates/external-secret.yaml
+++ b/helm/cedar/templates/external-secret.yaml
@@ -1,7 +1,7 @@
 ---
 {{- if .Values.global.externalSecrets.deploy }}
 {{- if not .Values.externalSecrets.createCedarClientSecret }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cedar-g3auto

--- a/helm/cohort-middleware/templates/external-secret.yaml
+++ b/helm/cohort-middleware/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sCohortMiddlewareSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cohort-middleware-g3auto

--- a/helm/common/templates/_aws_config.tpl
+++ b/helm/common/templates/_aws_config.tpl
@@ -17,7 +17,7 @@ data:
   access-key: {{ .Values.secrets.awsAccessKeyId | default .Values.global.aws.awsAccessKeyId | b64enc }}
   secret-access-key: {{ .Values.secrets.awsSecretAccessKey | default .Values.global.aws.awsSecretAccessKey | b64enc }}
 {{- else }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{.Chart.Name}}-aws-config

--- a/helm/common/templates/_external_secrets.tpl
+++ b/helm/common/templates/_external_secrets.tpl
@@ -17,7 +17,7 @@
 */}}
 {{- define "common.externalSecret.db" -}}
 {{ if .Values.global.externalSecrets.deploy }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $.Chart.Name }}-dbcreds
@@ -42,7 +42,7 @@ spec:
     External Secrets Secret Store will allow all charts to allow for authentication to AWS Secrets Manager
 */}}
 {{ define "common.secretstore" -}}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: {{.Chart.Name}}-secret-store

--- a/helm/dicom-server/templates/external-secrets.yaml
+++ b/helm/dicom-server/templates/external-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if not .Values.externalSecrets.createK8sOrthancS3G3auto}}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: orthanc-g3auto

--- a/helm/fence/templates/external-secret.yaml
+++ b/helm/fence/templates/external-secret.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.global.externalSecrets.deploy }}
 {{- if not .Values.externalSecrets.createK8sJwtKeysSecret}}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: fence-jwt-keys
@@ -25,7 +25,7 @@ spec:
 {{- end }}
 {{- if not .Values.externalSecrets.createK8sGoogleAppSecrets}}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: fence-google-app-creds-secret
@@ -49,7 +49,7 @@ spec:
       #name of secret in secrets manager
       key: {{include "fence-google-app-creds-secret" .}}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: fence-google-storage-creds-secret
@@ -75,7 +75,7 @@ spec:
 {{- end }}
 {{- if not .Values.externalSecrets.createK8sFenceConfigSecret}}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: fence-config
@@ -99,7 +99,7 @@ spec:
       key: {{include "fence-config" .}}
 {{- if .Values.usersync.syncFromDbgap }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: fence-ssh-keys

--- a/helm/gen3-user-data-library/templates/external-secret.yaml
+++ b/helm/gen3-user-data-library/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.global.externalSecrets.deploy }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: gen3userdatalibrary-g3auto

--- a/helm/gen3/templates/secret-store.yaml
+++ b/helm/gen3/templates/secret-store.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.global.externalSecrets.deploy (not .Values.global.aws.useLocalSecret.enabled) }}
 {{ include "common.secretstore" . }}
 {{- else if .Values.global.aws.useLocalSecret.enabled }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: {{.Chart.Name}}-secret-store

--- a/helm/gen3/templates/slack-webhook-external-secret.yaml
+++ b/helm/gen3/templates/slack-webhook-external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.global.externalSecrets.deploy) (.Values.global.externalSecrets.createSlackWebhookSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: slack-webhook

--- a/helm/indexd/templates/external-secrets.yaml
+++ b/helm/indexd/templates/external-secrets.yaml
@@ -3,7 +3,7 @@
 {{- end  }}
 ---
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sServiceCredsSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: indexd-service-creds

--- a/helm/manifestservice/templates/external-secret.yaml
+++ b/helm/manifestservice/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sManifestServiceSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: manifestservice-g3auto

--- a/helm/metadata/templates/external-secret.yaml
+++ b/helm/metadata/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sMetadataSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: metadata-g3auto

--- a/helm/orthanc/templates/external-secrets.yaml
+++ b/helm/orthanc/templates/external-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if not .Values.externalSecrets.createK8sOrthancS3G3auto}}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: orthanc-s3-g3auto

--- a/helm/sower/templates/external-secret.yaml
+++ b/helm/sower/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sPelicanServiceSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: pelicanservice-g3auto
@@ -19,7 +19,7 @@ spec:
 ---
 {{- end }}
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sSowerJobsSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: sower-jobs-g3auto

--- a/helm/ssjdispatcher/templates/external-secret.yaml
+++ b/helm/ssjdispatcher/templates/external-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.global.externalSecrets.deploy) (not .Values.externalSecrets.createK8sSsjdispatcherSecret) }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: ssjdispatcher-creds

--- a/helm/wts/templates/external-secret.yaml
+++ b/helm/wts/templates/external-secret.yaml
@@ -1,7 +1,7 @@
 ---
 {{ if .Values.global.externalSecrets.deploy }}
 {{ if not .Values.externalSecrets.createWtsOidcClientSecret }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: wts-oidc-client
@@ -22,7 +22,7 @@ spec:
 {{ end }}
 {{ if not .Values.externalSecrets.createK8sWtsSecret }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: wts-g3auto


### PR DESCRIPTION
## Problem Description
The release of External Secrets v0.17.0 introduced a breaking change by fully deprecating and removing support for the `apiVersion: external-secrets.io/v1beta1` chart from being able to utilize External Secrets versions v0.17.0 and later. Our current setup is restricted to a maximum version of v0.16.2.

## Proposed Solution
Update the `gen3-helm` chart to support External Secrets versions v0.17.0 and greater.

## Implementation Details
The core fix is straightforward: update all instances of the deprecated `apiVersion` in the chart resources.
- **Replace:** `apiVersion: external-secrets.io/v1beta1`
- **With:** `apiVersion: external-secrets.io/v1`


## Communication and Upgrade Strategy
Since the required change is minimal, the primary task is managing the transition for users/admins.

### Recommended Strategy:

1. **Recommended Gen3 Admins Upgrade to External Secrets v0.16.2:** This version is key because it is the last version that supports both `v1beta1` and `v1` API versions, making it a safe transition point. Admins can make this change now in preparation for the helm chart update without requiring it.

2. **Breaking Change Release:** Release a new version of the `gen3-helm` chart that implements the API change to `v1`.

3. **Communication:** Clearly document in the release notes that:
   - This `gen3-helm` chart version requires External Secrets v0.16.2 or greater.
   - Admins who are on an older External Secrets version (e.g., pre-v0.16.0) **must first** upgrade to External Secrets v0.16.2 before applying the new `gen3-helm` version and then finally upgrading to External Secrets v0.17.0+ to ensure a smooth transition.

4. **Optionally,** Admins can then upgrade to external-secrets v0.20.2 or whatever is latest at the time.

## Alternatives Considered

N/A - Direct modification of the gen3-helm chart is required for compatibility.

## Additional Context

- **External Secrets v0.16.2:** Supports both `v1beta1` and `v1` API versions. (Last dual-support version)
- **External Secrets v0.17.0+:** Only supports the final `v1` API version.
- **Relevant upstream release:** [external-secrets v0.17.0 release notes](https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0)

## Upgrade Notes

### For Admins Currently on Older External Secrets Versions

If you are running an older version of External Secrets (pre-v0.16.2):

1. **First,** upgrade External Secrets to v0.16.2
2. **Then,** apply this gen3-helm chart update
3. **Finally,** upgrade to External Secrets v0.17.0+ safely

This ensures compatibility throughout the upgrade path since v0.16.2 supports both API versions.



